### PR TITLE
chore: bump ntapi

### DIFF
--- a/heim-cpu/Cargo.toml
+++ b/heim-cpu/Cargo.toml
@@ -23,7 +23,7 @@ glob = "^0.3"
 smol = "^1.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-ntapi = "^0.3"
+ntapi = "^0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = ">=0.3.8"

--- a/heim-host/Cargo.toml
+++ b/heim-host/Cargo.toml
@@ -31,7 +31,7 @@ mach = "0.3.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = ">=0.3.8", features = ["sysinfoapi", "ws2def", "winbase", "minwindef", "winnt"] }
-ntapi = "^0.3"
+ntapi = "^0.4"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/heim-process/Cargo.toml
+++ b/heim-process/Cargo.toml
@@ -35,7 +35,7 @@ smol = "^1.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 heim-host = { version = "0.1.0-rc.1", path = "../heim-host" }
-ntapi = "0.3.3"
+ntapi = "^0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = ">=0.3.8"


### PR DESCRIPTION
getting rid of the warning 
```
warning: the following packages contain code that will be rejected by a future version of Rust: ntapi v0.3.7
```

this change also bumps the MRV to 1.64 @dilawar 